### PR TITLE
eslint: use "readonly" for globals in place of deprecated value

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,14 +4,14 @@
   "overrides": [
     {
       "files": ["*.md"],
-      "globals": {"$": false, "Pair": false, "S": false, "Z": false},
+      "globals": {"$": "readonly", "Pair": "readonly", "S": "readonly", "Z": "readonly"},
       "rules": {
         "array-element-newline": ["off"]
       }
     },
     {
       "files": ["index.js"],
-      "globals": {"Deno": false, "process": false},
+      "globals": {"Deno": "readonly", "process": "readonly"},
       "rules": {
         "multiline-comment-style": ["off"]
       }


### PR DESCRIPTION
Relates to sanctuary-js/sanctuary-style#33
